### PR TITLE
V5.0

### DIFF
--- a/LMS_main.py
+++ b/LMS_main.py
@@ -65,13 +65,13 @@ class LMS:
     def loginuser(self):
         self.newWindow = ctk.CTk()
         # root = ctk.CTk()
-        basedesk.get_accountpermission(ac)
+        basedesk.get_accountpermission(ac,govid)
         B = basedesk.Basedesk(self.newWindow)
         self.newWindow.mainloop()
     #admin登入
     def loginuseradmin(self,permission):
         self.newWindow = ctk.CTk()
-        basedesk_admin.get_accountpermission(ac,permission)
+        basedesk_admin.get_accountpermission(ac,permission,govid,verifyAccount.hos_rematrix(self.hospital_code))
         B = basedesk_admin.Basedesk_Admin(self.newWindow)
         self.newWindow.mainloop()
 

--- a/basedesk.py
+++ b/basedesk.py
@@ -13,9 +13,10 @@ from verifyAccount import changepw_sql
 # from counter import getaccount
 # global account
 # account = sys.argv[1]
-def get_accountpermission(acount):
-    global Baccount
+def get_accountpermission(acount,govid):
+    global Baccount,Govid
     Baccount = str(acount)
+    Govid = str(govid)
 
     return None
 
@@ -259,7 +260,7 @@ class Basedesk:
         from counter import Count
         self.master.withdraw() #把basedesk隱藏
         self.newWindow = ctk.CTkToplevel()
-        counter.getaccount(Baccount)
+        counter.getaccount(Baccount,Govid)
         C = Count(self.newWindow,self.master)
     def urinesedimentcounter(self):
         self.destroy()
@@ -282,7 +283,7 @@ class Basedesk:
         from counter_practise import PRACTISE
         self.master.withdraw() #把basedesk隱藏
         self.newWindow = ctk.CTkToplevel()
-        counter_practise.getaccount(Baccount)
+        counter_practise.getaccount(Baccount,Govid)
         P = PRACTISE(self.newWindow,self.master)
     def image_practise(self,level):
         import practice_image

--- a/basedesk_admin.py
+++ b/basedesk_admin.py
@@ -13,10 +13,12 @@ from setuptools import Command
 # global account
 # account = sys.argv[1]
 
-def get_accountpermission(acount,permission):
-    global Baccount,Permission
+def get_accountpermission(acount,permission,govid,hoscode):
+    global Baccount,Permission,Govid,Hos_code
     Permission = str(permission)
     Baccount = str(acount)
+    Govid = str(govid)
+    Hos_code = str(hoscode)
     return None
 class Basedesk_Admin:
     
@@ -35,7 +37,7 @@ class Basedesk_Admin:
         s.configure('Red.TLabelframe.Label', font=('微軟正黑體', 12))
         s.configure('Red.TLabelframe.Label', foreground ='#FFFFFF')
         s.configure('Red.TLabelframe.Label', background='#FFEEDD')
-        self.hellow_label = ctk.CTkLabel(
+        self.hello_label_user = ctk.CTkLabel(
             self.master, 
             # text = "歡迎回來",
             text = "歡迎回來 %s"%(Baccount),
@@ -44,8 +46,8 @@ class Basedesk_Admin:
             text_color="#000000",
             width=240
             )
-        self.hellow_label.pack()
-        self.label_1 = ctk.CTkLabel(
+        self.hello_label_user.pack()
+        self.hello_label_function = ctk.CTkLabel(
             self.master, 
             text = "請選擇需要使用的功能:", 
             fg_color='#FFEEDD',
@@ -53,7 +55,7 @@ class Basedesk_Admin:
             text_color="#000000",
             width=300
             )
-        self.label_1.pack()
+        self.hello_label_function.pack()
         ##框架設置
         self.labelframe_1 = ctk.CTkFrame(
             self.master,
@@ -156,7 +158,7 @@ class Basedesk_Admin:
             text_color="#000000"
             )
         self.btn_allscore.pack(padx=10, pady=15)
-        self.button_3=ctk.CTkButton(
+        self.button_import=ctk.CTkButton(
             self.labelframe_3,
             command = self.scoreimport, 
             text = "考題匯入", 
@@ -165,8 +167,8 @@ class Basedesk_Admin:
             font=('微軟正黑體',22),
             text_color="#000000"
             )
-        self.button_3.pack(padx=10, pady=15)
-        self.button_3m=ctk.CTkButton(
+        self.button_import.pack(padx=10, pady=15)
+        self.button_test_config=ctk.CTkButton(
             self.labelframe_3,
             command = self.testmodify, 
             text = "考題參數設定", 
@@ -175,8 +177,28 @@ class Basedesk_Admin:
             font=('微軟正黑體',22),
             text_color="#000000"
             )
-        self.button_3m.pack(padx=10, pady=15)
-        self.button_3s=ctk.CTkButton(
+        self.button_test_config.pack(padx=10, pady=15)
+        self.button_hos_import=ctk.CTkButton(
+            self.labelframe_3,
+            command = self.hos_scoreimport, 
+            text = "(各院區)\n考題匯入", 
+            fg_color='#FF9900',
+            width=160,height=40,
+            font=('微軟正黑體',22),
+            text_color="#000000"
+            )
+        self.button_hos_import.pack(padx=10, pady=15)
+        self.button_hos_test_config=ctk.CTkButton(
+            self.labelframe_3,
+            command = self.hos_testmodify, 
+            text = "(各院區)\n考題參數設定", 
+            fg_color='#FF9900',
+            width=160,height=40,
+            font=('微軟正黑體',22),
+            text_color="#000000"
+            )
+        self.button_hos_test_config.pack(padx=10, pady=15)
+        self.button_export=ctk.CTkButton(
             self.labelframe_2,
             command = self.output_score, 
             text = "成績匯出", 
@@ -185,8 +207,8 @@ class Basedesk_Admin:
             font=('微軟正黑體',22),
             text_color="#000000"
             )
-        self.button_3s.pack(padx=10, pady=15)
-        self.button_3t=ctk.CTkButton(
+        self.button_export.pack(padx=10, pady=15)
+        self.button_scoretest=ctk.CTkButton(
             self.labelframe_2,
             command = self.scorecal_test, 
             text = "成績試算", 
@@ -195,8 +217,8 @@ class Basedesk_Admin:
             font=('微軟正黑體',22),
             text_color="#000000"
             )
-        self.button_3t.pack(padx=10, pady=15)
-        self.button_3t=ctk.CTkButton(
+        self.button_scoretest.pack(padx=10, pady=15)
+        self.button_score=ctk.CTkButton(
             self.labelframe_2,
             command = self.scorecal, 
             text = "成績計算", 
@@ -205,7 +227,7 @@ class Basedesk_Admin:
             font=('微軟正黑體',22),
             text_color="#000000"
             )
-        self.button_3t.pack(padx=10, pady=15)
+        self.button_score.pack(padx=10, pady=15)
         self.button_4=ctk.CTkButton(
             self.labelframe_4,
             command = self.IDmanage, 
@@ -270,8 +292,8 @@ class Basedesk_Admin:
             width=80)
         self.versioninfo.pack()
     # def gui_arrang(self):
-        self.hellow_label.place(relx=0.5, rely=0.05, anchor=tk.CENTER)
-        self.label_1.place(relx=0.5, rely=0.13, anchor=tk.CENTER)
+        self.hello_label_user.place(relx=0.5, rely=0.05, anchor=tk.CENTER)
+        self.hello_label_function.place(relx=0.5, rely=0.13, anchor=tk.CENTER)
         self.button_5.place(relx=0.2,rely=0.9,anchor=tk.CENTER)
         self.button_6.place(relx=0.5,rely=0.9,anchor=tk.CENTER)
         self.button_changepw.place(relx=0.8,rely=0.9,anchor=tk.CENTER)
@@ -279,20 +301,23 @@ class Basedesk_Admin:
         self.versioninfo.place(relx=0, rely=1,anchor=tk.SW) 
         self.labelframe_1.place(relx=0.17,rely=0.395, anchor=tk.CENTER)
         self.labelframe_2.place(relx=0.52,rely=0.455, anchor=tk.CENTER)
-        self.labelframe_3.place(relx=0.85,rely=0.34, anchor=tk.CENTER)
+        self.labelframe_3.place(relx=0.85,rely=0.49, anchor=tk.CENTER)
         self.labelframe_4.place(relx=0.85,rely=0.78, anchor=tk.CENTER)
         self.labelframe_5.place(relx=0.31,rely=0.78, anchor=tk.CENTER)
         self.permission_able()
     def permission_able(self):
         if Permission=="useradmin":
-            self.button_practise.configure(state="disabled")
-            self.button_image_pracrice.configure(state="disabled")
+            self.labelframe_5.place_forget()
+            self.labelframe_4.place(relx=0.17,rely=0.78, anchor=tk.CENTER)
         elif Permission=="master":
             self.button_5.configure(state="normal")
         elif Permission=="primarysupervisor":
+            self.labelframe_4.place_forget()
             self.button_4.configure(state="disabled")
         elif Permission=="secondarysupervisor":
-            self.button_4.configure(state="disabled")
+            self.labelframe_4.place_forget()
+            self.button_import.configure(state="disabled")
+            self.button_test_config.configure(state="disabled")
             self.btn_allscore.configure(state="disabled")
 
     def changepw(self):
@@ -342,7 +367,7 @@ class Basedesk_Admin:
         from counter import Count
         self.master.withdraw() #把basedesk隱藏
         self.newWindow = ctk.CTkToplevel()
-        counter.getaccount(Baccount)
+        counter.getaccount(Baccount,Govid)
         C = Count(self.newWindow,self.master)
     def urinesedimentcounter(self):
         self.destroy()
@@ -365,7 +390,7 @@ class Basedesk_Admin:
         from counter_practise import PRACTISE
         self.master.withdraw() #把basedesk隱藏
         self.newWindow = ctk.CTkToplevel()
-        counter_practise.getaccount(Baccount)
+        counter_practise.getaccount(Baccount,Govid)
         P = PRACTISE(self.newWindow,self.master)
     def image_practise(self,level):
         import practice_image
@@ -383,15 +408,34 @@ class Basedesk_Admin:
         ScoreSearch.getaccount(Baccount)
         S = Search(self.newWindow,self.master)
     def scoreimport(self):
+        import scoreImport
         from scoreImport import Import
         self.master.withdraw() #把basedesk隱藏
         self.newWindow = ctk.CTkToplevel()
+        scoreImport.gethos('D')
         I = Import(self.newWindow,self.master)
         # self.newWindow['bg'] = "#FFEEDD"
     def testmodify(self):
+        import testmodify
         from testmodify import Modify
         self.master.withdraw() #把basedesk隱藏
         self.newWindow = ctk.CTkToplevel()
+        testmodify.gethos('D')
+        M = Modify(self.newWindow,self.master)
+    def hos_scoreimport(self):
+        import scoreImport
+        from scoreImport import Import
+        self.master.withdraw() #把basedesk隱藏
+        self.newWindow = ctk.CTkToplevel()
+        scoreImport.gethos(Hos_code)
+        I = Import(self.newWindow,self.master)
+        # self.newWindow['bg'] = "#FFEEDD"
+    def hos_testmodify(self):
+        import testmodify
+        from testmodify import Modify
+        self.master.withdraw() #把basedesk隱藏
+        self.newWindow = ctk.CTkToplevel()
+        testmodify.gethos(Hos_code)
         M = Modify(self.newWindow,self.master)
     def output_score(self):
         from output_score import OUTPUT_SCORE

--- a/counter.py
+++ b/counter.py
@@ -14,11 +14,11 @@ freq = 600  # Hz
 duration_1 = 900  # millisecond
 freq_1 = 1000  # Hz
 
-def getaccount(acount):
-    global Baccount
+def getaccount(acount,govid):
+    global Baccount,Govid
     Baccount = str(acount) 
+    Govid = str(govid)
     # Baccount = "henry423"
-    print(Baccount)
     return None
 
 def resource_path(relative_path):
@@ -719,6 +719,17 @@ class Count:    #建立計數器
             text_color="#000000",
             )
         self.input_needcountval.grid(row=10,column=5)
+        self.btn_phrase = ctk.CTkButton(
+            self.frame_counter,
+            text="預設片語",
+            command= self.add_phrase,
+            fg_color="#CCCCCC",
+            corner_radius=8,
+            width=70,height=30,
+            font=('微軟正黑體',20),
+            text_color="#000000"
+        )
+        self.btn_phrase.grid(row=10,column=8,columnspan=2)
     # def gui_arrang(self):
         self.frame_exam.grid(row=0, column=0,columnspan=2,pady=20,sticky=tk.W)
         self.frame_time.grid(row=1, column=0,padx=3,ipadx=20)
@@ -808,6 +819,51 @@ class Count:    #建立計數器
     def stop_clock(self):
         self.doTick = False
 
+    def add_phrase(self):
+        style = ttk.Style()
+        style.configure("Treeview",borderwidth=1,relief='solid',font=(None,14))
+        window_phrase = ctk.CTkToplevel()
+        window_phrase.title("片語選擇")
+        window_phrase.geometry("400x300")
+        # 創建 Treeview 表格
+        columns = ("#1", "#2")
+        tree = ttk.Treeview(window_phrase, columns=columns, show="headings",style="Treeview")
+        # 設置表頭
+        tree.heading("#1", text="編號")
+        tree.heading("#2", text="片語")
+        # 調整欄位的寬度
+        tree.column("#1", width=50, anchor='center')  # 編號欄位寬度縮小
+        tree.column("#2", width=300, anchor='w')     # 片語欄位寬度增大
+        # 插入數據到表格
+        data = [
+            ("1","Preliminary report"),
+            ("2","PANIC VALUE ! 危險值通知 !"),
+            ("3","NRBC五顆以上，需補傳NRBC"),
+            ("4","Auer rod(+)"),
+            ("5","Smudge cell (+)"),
+            ("6","Faggot cell(+)"),
+            ("7","Rieder cell(+)"),
+            ("8","RBC Rouleaux formation(+)"),
+            ("9","Abnormal lymphocyte with large/small cleaved"),
+            ("10","Abnormal lymphoid cells with villous or cytoplasmic projections"),
+            ("11","Abn-Lym with irregular nucleus")
+        ]
+        for item in data:
+            tree.insert("", "end", values=item)
+        tree.pack(expand=True,fill="both")
+        # 雙擊事件處理函數
+        def on_double_click(event):
+            selected_item = tree.focus()  # 獲取當前選中的項目
+            if selected_item:
+                selected_table = tree.item(selected_item, "values")
+                selected_phrase = selected_table[1]  # 選取 "片語" 欄位的內容
+                
+                window_phrase.destroy()  # 關閉 new_window 視窗
+            else:
+                return
+            self.input_testcomment.insert("end",", " + str(selected_phrase))
+        # 將雙擊事件與表格綁定
+        tree.bind("<Double-1>", on_double_click)
     
     #函式判別上/下數、判別是否數錯方向
     def pending(self,event):
@@ -1021,7 +1077,7 @@ class Count:    #建立計數器
                     ans.append(rawcount)
             ##確認輸入者id
             with coxn.cursor() as cursor:
-                cursor.execute("SELECT No FROM[bloodtest].[dbo].[id] WHERE [ac]='%s';" %(Baccount))
+                cursor.execute("SELECT No FROM[bloodtest].[dbo].[id] WHERE [govid]='%s';" %(Govid))
                 ac = cursor.fetchone()[0]
             ##存入SQL
             with coxn.cursor() as cursor:

--- a/counter_practise.py
+++ b/counter_practise.py
@@ -14,11 +14,11 @@ freq = 600  # Hz
 duration_1 = 900  # millisecond
 freq_1 = 1000  # Hz
 
-def getaccount(acount):
-    global Baccount
+def getaccount(acount,govid):
+    global Baccount,Govid
     Baccount = str(acount) 
+    Govid = str(govid)
     # Baccount = "henry423"
-    print(Baccount)
     return None
 
 def resource_path(relative_path):
@@ -1076,7 +1076,7 @@ class PRACTISE:    #建立計數器
                     ans.append(rawcount)
             ##確認輸入者id
             with coxn.cursor() as cursor:
-                cursor.execute("SELECT No FROM[bloodtest].[dbo].[id] WHERE [ac]='%s';" %(Baccount))
+                cursor.execute("SELECT No FROM[bloodtest].[dbo].[id] WHERE [govid]='%s';" %(Govid))
                 ac = cursor.fetchone()[0]
             ##存入SQL
             with coxn.cursor() as cursor:

--- a/scoreImport.py
+++ b/scoreImport.py
@@ -1,4 +1,4 @@
-import sys, os,shutil
+import sys, os,shutil,verifyAccount
 import tkinter as tk
 from tkinter import ttk
 from tkinter import RIDGE, DoubleVar, StringVar, ttk, messagebox,IntVar, filedialog
@@ -12,6 +12,11 @@ def getaccount(acount):
     global Baccount
     Baccount = str(acount)
     # print(Baccount)
+    return None
+#取得院區代碼
+def gethos(hospital):
+    global Hoscode
+    Hoscode = str(hospital)
     return None
 
 def resource_path(relative_path):
@@ -109,6 +114,28 @@ class Import:
         )
         self.welcome.pack()
         self.welcome.place(relx=0.5,rely=0.05,anchor=tk.CENTER)
+        self.label_hos = ctk.CTkLabel(
+            self.master,
+            text="院區選擇:",
+            bg_color='#FFEEDD',
+            font=('微軟正黑體',30),
+            text_color='#000000',
+            fg_color="#FFEEDD",
+            width=240
+        )
+        self.label_hos.pack()
+        self.label_hos.place(relx=0.1,rely=0.05,anchor=tk.CENTER)
+        self.hospital_name = ctk.CTkLabel(
+            self.master,
+            text=str(verifyAccount.hos_matrix(Hoscode)),
+            bg_color='#FFEEDD',
+            font=('微軟正黑體',30),
+            text_color='#0072E3',
+            fg_color="#FFEEDD",
+            width=120
+        )
+        self.hospital_name.pack()
+        self.hospital_name.place(relx=0.23,rely=0.05,anchor=tk.CENTER)
         ###建立分頁窗格
         self.tab = ctk.CTkTabview(
             self.master,
@@ -418,6 +445,13 @@ class Import:
         self.labelframe_nok.pack_forget()
         self.labelframe_vfnok.pack_forget()
         self.labelframe_vfok.pack_forget()
+        # self.select_hos(Hoscode)
+    ##分成院區上傳或者行政中心上傳
+    # def select_hos(self,Hoscode):
+    #     if Hoscode=='D':
+    #         pass
+    #     else:
+
     ##選擇檔案後，驗證是否匯入成功
     def selectfile(self):
         global testtype
@@ -463,7 +497,7 @@ class Import:
         except ValueError:
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
             self.labelframe_nok.tkraise()
-            tk.messagebox.showerror('土城長庚醫院檢驗科', message='資料格式不符，請重新選擇檔案')
+            tk.messagebox.showerror('檢驗醫學部(科)', message='資料格式不符，請重新選擇檔案')
             return None
         except FileNotFoundError:
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
@@ -527,7 +561,7 @@ class Import:
         try:
             createtable(self.verifyframe,7,9,2,lst=db)
         except IndexError:
-            tk.messagebox.showerror("土城長庚醫院檢驗科", message='檔案格式不符，請檢查後再上傳')
+            tk.messagebox.showerror("檢驗醫學部(科)", message='檔案格式不符，請檢查後再上傳')
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
             self.labelframe_nok.tkraise()
             return None
@@ -604,7 +638,7 @@ class Import:
         except ValueError:
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
             self.labelframe_nok.tkraise()
-            tk.messagebox.showerror('土城長庚醫院檢驗科', message='資料格式不符，請重新選擇檔案')
+            tk.messagebox.showerror('檢驗醫學部(科)', message='資料格式不符，請重新選擇檔案')
             return None
         except FileNotFoundError:
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
@@ -679,7 +713,7 @@ class Import:
             self.labelframe_ok.place_forget()
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
             self.labelframe_nok.tkraise()
-            tk.messagebox.showerror('土城長庚醫院檢驗科', message='資料格式不符，請重新選擇檔案')
+            tk.messagebox.showerror('檢驗醫學部(科)', message='資料格式不符，請重新選擇檔案')
             return None
         except FileNotFoundError:
             self.labelframe_nok.place(relx=0.15,rely=0.42,anchor=tk.CENTER)
@@ -853,10 +887,14 @@ class Import:
         # print(rawdata,lst_r,lst_a)
         #匯入SQL
         with coxn.cursor() as cursor:
+        #Hoscode轉換
+            sql_hos_no="SELECT [No] FROM [hospital_code] WHERE[code]='%s'"%(Hoscode)
+            cursor.execute(sql_hos_no)
+            hos_no = int(cursor.fetchone()[0])
         #匯入bloodinfo table
             bloodinfo_input = """INSERT INTO [bloodtest].[dbo].[bloodinfo]
-            ("year","smear_id","gender","age","count_value","comment")
-            VALUES (%s,'%s','%s',%d,%d,'%s');""" %(self.testyear,self.testname,self.gender,self.age,self.count_value,self.comment)
+            ("year","smear_id","gender","age","count_value","comment","branch")
+            VALUES (%s,'%s','%s',%d,%d,'%s',%d);""" %(self.testyear,self.testname,self.gender,self.age,self.count_value,self.comment,hos_no)
         #匯入bloodinfo_cbc table
             bloodinfocbc_input = """INSERT INTO [bloodtest].[dbo].[bloodinfo_cbc]
             ("smear_id","WBC","RBC","HB","Hct","MCV","MCH","MCHC","RDW","plt")

--- a/testmodify.py
+++ b/testmodify.py
@@ -37,6 +37,12 @@ def resource_path(relative_path):
 
     return os.path.join(base_path, relative_path)
 
+#取得院區代碼
+def gethos(hospital):
+    global Hoscode
+    Hoscode = str(hospital)
+    return None
+
 class Modify:
     
     def __init__(self,master,oldmaster=None):  
@@ -49,9 +55,13 @@ class Modify:
         # rawdata = json.load(jsonfile)
         # self.rawdata = pd.DataFrame(rawdata["blood"])
         with coxn.cursor() as cursor:
+            # sql_hospital="SELECT DISTINCT [year] FROM [bloodtest].[dbo].[bloodinfo] JOIN [hospital_code] ON [bloodinfo].[branch]=[hospital_code].[No] WHERE [];"
             cursor.execute("SELECT DISTINCT [year] FROM [bloodtest].[dbo].[bloodinfo];")
         # self.testyear = self.rawdata['year'].unique().tolist()
             self.testyear = [str(row[0]) for row in cursor.fetchall()]
+        with coxn.cursor() as cursor:
+            cursor.execute("SELECT [院區] FROM [bloodtest].[dbo].[hospital_code];")
+            self.hospital = [str(row[0]) for row in cursor.fetchall()]
         # 給主視窗設定標題內容  
         self.master.title("考題設定")  
         self.master.geometry('900x650')
@@ -193,16 +203,38 @@ class Modify:
                     width=120,height=120
                     )
         self.label_2.grid(row=0,column=0,columnspan=5,sticky='nsew')
-        #(f2)年份標籤 & 下拉欄位
+        #(f2)院區標籤 & 年份標籤 & 下拉欄位
+        self.label_hospital= ctk.CTkLabel(
+                    self.labelframe_2, 
+                    text = "請選擇院區:", 
+                    fg_color='#FFEEDD',
+                    font=('微軟正黑體',20),
+                    text_color="#000000",
+                    width=140,height=40
+                    )
+        self.label_hospital.grid(row=1,column=0,pady=10,sticky='w')
+        self.input_hospital= ctk.CTkComboBox(
+                    master = self.labelframe_2,
+                    # command= None,
+                    command= self.updateyearcombobox,
+                    values=self.hospital,
+                    text_color='#000000',
+                    fg_color='#F0F0F0',
+                    button_color='#FF9900',
+                    state="readonly",
+                    width=140,height=40,
+                    font=('微軟正黑體',16,)
+                    )
+        self.input_hospital.grid(row=1,column=1,padx=10,pady=10,columnspan=2,sticky='w')
         self.label_year = ctk.CTkLabel(
                     self.labelframe_2, 
                     text = "請選擇考核年度:", 
                     fg_color='#FFEEDD',
                     font=('微軟正黑體',20),
                     text_color="#000000",
-                    width=140,height=40
+                    width=70,height=40
                     )
-        self.label_year.grid(row=1,column=0,pady=10,sticky='w')
+        self.label_year.grid(row=1,column=3,pady=10,sticky='w')
         self.input_year = ctk.CTkComboBox(
                     master = self.labelframe_2,
                     # command= None,
@@ -215,7 +247,7 @@ class Modify:
                     width=120,height=40,
                     font=('微軟正黑體',16,)
                     )
-        self.input_year.grid(row=1,column=1,padx=10,pady=10,columnspan=2,sticky='w')
+        self.input_year.grid(row=1,column=4,pady=10,sticky='w')
         #(f2)左邊考題選擇listbox & 旁邊捲軸
         self.scrollbar = tk.Scrollbar(self.labelframe_2)
         
@@ -401,6 +433,14 @@ class Modify:
             fg_color='#FF0000',
             text_color='#000000')
         self.delete_btn.grid(row=5,column=4,padx=20,pady=5)
+        if Hoscode!='D':
+            with coxn.cursor() as cursor:
+                sql_hos = "SELECT [院區] FROM [bloodtest].[dbo].[hospital_code] WHERE [code]='%s';"%(Hoscode)
+                cursor.execute(sql_hos)
+                self.hos_name=str(cursor.fetchone()[0])
+            self.input_hospital.set(self.hos_name)
+            self.updateyearcombobox(self)
+            self.input_hospital.configure(state='disabled')
 
 ##左手邊按鍵區域 血液考題設定/血液參數設定/尿液考題設定/離開
     #(f3)參數設定介面介面
@@ -422,16 +462,38 @@ class Modify:
                     width=120,height=120,
                     )
         self.label_3.grid(row=0,column=0,columnspan=6,sticky='nsew')
-        #(f3)年份標籤 & 下拉欄位
+        #(f3)年份院區標籤 & 下拉欄位
+        self.f3_label_hospital = ctk.CTkLabel(
+                    self.labelframe_3, 
+                    text = "請選擇院區:", 
+                    fg_color='#FFEEDD',
+                    font=('微軟正黑體',20),
+                    text_color="#000000",
+                    width=140,height=40
+                    )
+        self.f3_label_hospital.grid(row=1,column=0,pady=10,sticky='w')
+        self.f3_input_hospital = ctk.CTkComboBox(
+                    master = self.labelframe_3,
+                    # command= None,
+                    command= self.f3_updateyearcombobox,
+                    values=self.hospital,
+                    text_color='#000000',
+                    fg_color='#F0F0F0',
+                    button_color='#FF9900',
+                    state="readonly",
+                    width=140,height=40,
+                    font=('微軟正黑體',16,)
+                    )
+        self.f3_input_hospital.grid(row=1,column=1,padx=10,pady=10,columnspan=2,sticky='w')
         self.f3_label_year = ctk.CTkLabel(
                     self.labelframe_3, 
                     text = "請選擇考核年度:", 
                     fg_color='#FFEEDD',
                     font=('微軟正黑體',20),
                     text_color="#000000",
-                    width=140,height=40
+                    width=70,height=40
                     )
-        self.f3_label_year.grid(row=1,column=0,pady=10,sticky='w')
+        self.f3_label_year.grid(row=1,column=3,pady=10,sticky='w')
         self.f3_input_year = ctk.CTkComboBox(
                     master = self.labelframe_3,
                     # command= None,
@@ -444,7 +506,7 @@ class Modify:
                     width=120,height=40,
                     font=('微軟正黑體',16,)
                     )
-        self.f3_input_year.grid(row=1,column=1,padx=10,pady=10,columnspan=2,sticky='w')
+        self.f3_input_year.grid(row=1,column=4,pady=10,columnspan=2,sticky='w')
         #(f3)左邊考題選擇listbox & 旁邊捲軸
         self.scrollbar = tk.Scrollbar(self.labelframe_3)
         
@@ -627,6 +689,15 @@ class Modify:
             fg_color='#FF0000',
             text_color='#000000')
         self.f3_delete_btn.grid(row=5,column=4,padx=20,pady=5)
+        if Hoscode!='D':
+            with coxn.cursor() as cursor:
+                sql_hos = "SELECT [院區] FROM [bloodtest].[dbo].[hospital_code] WHERE [code]='%s';"%(Hoscode)
+                cursor.execute(sql_hos)
+                self.hos_name=str(cursor.fetchone()[0])
+            self.f3_input_hospital.set(self.hos_name)
+            self.f3_updateyearcombobox(self)
+            self.f3_input_hospital.configure(state='disabled')
+    
 
     #(f1)離開
     def exit(self,oldmaster):
@@ -752,11 +823,26 @@ class Modify:
             else:
                 return
 ##(f2)事件連結
+    #選擇院區之後，更新year_combobox
+    def updateyearcombobox(self,event):
+        #選擇院區之前，先把year & listbox清空
+        self.input_year.set("")
+        self.test_listbox.delete(0,tk.END)
+        self.hos_name=self.input_hospital.get()
+        with coxn.cursor() as cursor:
+            cursor.execute("""SELECT DISTINCT [year] FROM [bloodtest].[dbo].[bloodinfo] 
+JOIN [bloodtest].[dbo].[hospital_code] ON [bloodinfo].[branch]=[hospital_code].[No] 
+WHERE [hospital_code].[院區]='%s';"""%(self.hos_name))
+            sql_hosyear = [str(row[0]) for row in cursor.fetchall()]
+        self.input_year.configure(values=sql_hosyear)
     #選擇年份之後，更新listbox(JSON裡面有的考題)
+    
     def updatelist(self,event):
         #建立年分與smearid的dict
         with coxn.cursor() as cursor:
-            cursor.execute('SELECT "year","smear_id" FROM [bloodtest].[dbo].[bloodinfo];')
+            cursor.execute("""SELECT "year","smear_id" FROM [bloodtest].[dbo].[bloodinfo]
+JOIN [bloodtest].[dbo].[hospital_code] ON [bloodinfo].[branch]=[hospital_code].[No]
+WHERE [hospital_code].[院區]='%s';"""%(self.hos_name))
             sql_yearid = cursor.fetchall()
         yearid = dict()
         for row in sql_yearid:
@@ -949,11 +1035,25 @@ class Modify:
             else:
                 return
 ##(f3)事件連結
+    #選擇院區之後，更新year_combobox
+    def f3_updateyearcombobox(self,event):
+        #選擇院區之前，先把year & listbox清空
+        self.f3_input_year.set("")
+        self.f3_test_listbox.delete(0,tk.END)
+        self.hos_name=self.f3_input_hospital.get()
+        with coxn.cursor() as cursor:
+            cursor.execute("""SELECT DISTINCT [year] FROM [bloodtest].[dbo].[bloodinfo] 
+JOIN [bloodtest].[dbo].[hospital_code] ON [bloodinfo].[branch]=[hospital_code].[No] 
+WHERE [hospital_code].[院區]='%s';"""%(self.hos_name))
+            sql_hosyear = [str(row[0]) for row in cursor.fetchall()]
+        self.f3_input_year.configure(values=sql_hosyear)
     #(f3)選擇年份之後，更新listbox(JSON裡面有的考題)
     def f3_updatelist(self,event):
         #取得combobox選擇的年份
         with coxn.cursor() as cursor:
-            cursor.execute('SELECT "year","smear_id" FROM [bloodtest].[dbo].[bloodinfo];')
+            cursor.execute("""SELECT "year","smear_id" FROM [bloodtest].[dbo].[bloodinfo]
+JOIN [bloodtest].[dbo].[hospital_code] ON [bloodinfo].[branch]=[hospital_code].[No]
+WHERE [hospital_code].[院區]='%s';"""%(self.hos_name))
             sql_yearid = cursor.fetchall()
         yearid = dict()
         for row in sql_yearid:

--- a/verifyAccount.py
+++ b/verifyAccount.py
@@ -189,27 +189,43 @@ def delaccount(account):
     #     r.close()
     return "success"
 ##(UPDATE)edit account(for manager)
-def editaccount(oldaccount,newaccount):
+def editaccount(govid,newaccount,permission):
+    ##需要先檢查是否更動為admin
+    #名稱要轉為Order
     with coxn.cursor() as cursor:
-        sql = """UPDATE [bloodtest].[dbo].[id] SET [ac] = '%s' WHERE [ac]='%s';"""%(newaccount,oldaccount)
-        cursor.execute(sql)
-    coxn.commit()
-    # jsonfile = open('in.json','rb')
-    # a = json.load(jsonfile)
-    # ml = a['member']
-    # md = {}
-    # for i in ml:
-    #     x = i['ID']
-    #     y = i['token']
-    #     md[x] = y
-    # IL = [key for key in md.keys()]
-    # idx = IL.index(oldaccount)
-    # ml[idx]["ID"] = newaccount
-    # # print(ml)
-    # with open('in.json','w') as r:
-    #     json.dump(a,r)
-    #     r.close()
-    return "success"
+        sql_permission="SELECT [permission_name],[Order] FROM permission;"
+        cursor.execute(sql_permission)
+        dict_permission = dict(cursor.fetchall())
+    try:
+        update_permission_code = dict_permission[permission]
+ 
+        if update_permission_code==0:
+            return "admin"
+    except KeyError:
+        return "nopermission"
+    else:
+        with coxn.cursor() as cursor:
+            sql = """UPDATE [bloodtest].[dbo].[id] 
+            SET [ac] = '%s', [permission]=%d
+            WHERE [govid]='%s';"""%(newaccount,update_permission_code,govid[0])
+            cursor.execute(sql)
+        coxn.commit()
+        # jsonfile = open('in.json','rb')
+        # a = json.load(jsonfile)
+        # ml = a['member']
+        # md = {}
+        # for i in ml:
+        #     x = i['ID']
+        #     y = i['token']
+        #     md[x] = y
+        # IL = [key for key in md.keys()]
+        # idx = IL.index(oldaccount)
+        # ml[idx]["ID"] = newaccount
+        # # print(ml)
+        # with open('in.json','w') as r:
+        #     json.dump(a,r)
+        #     r.close()
+        return "success"
 
 def verifyAccountData_sql(account,password):
     # with open('pw.pickle','rb') as usr_file:


### PR DESCRIPTION
[更新] SQL欄位
[新增] 角色權限，分成五個角色:
    1. 程式管理員(administrator)
    2. 角色管理員(useradmin)
    3. 主要管理者(primarysupervisor)
    4. 次要管理者(secondarysupervisor)
    5. 使用者(user)
    角色依據不同權限有不同功能
[更新] counter.py中的片語系統
[修正] counter.py中，原先使用ac作為賞上傳結果的依據，現改為govid身分證字號
[更新] IDmanage.py 新增角色欄位，並且附加修改權限條件
[修正] LMS_main.py 增加govid身分證字號驗證
[更新] scoreImport.py 為符合權限，調整上傳SQL語句
[更新] testmodify.py 為符合權限，調整上傳SQL語句